### PR TITLE
### Updated AlbumsAPI and Albums

### DIFF
--- a/RecordCollection/Program.cs
+++ b/RecordCollection/Program.cs
@@ -20,6 +20,12 @@ builder.Services.AddDbContext<RecordCollectionContext>(options =>
     options.UseNpgsql(connectionString)
     .UseSnakeCaseNamingConvention());
 
+Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()
+                .WriteTo.File("Logs/Logs.txt", rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/RecordCollection/RecordCollection.csproj
+++ b/RecordCollection/RecordCollection.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Logs\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### Albums:
* Index: added null check
* Show: added null check for ID, added a try-catch to console and file log errors locating the album.
* Create: added ModelState check with an attached log, implemented a try-catch to try to save an album, and to catch a DB save fail.
* Delete: added null check, updated the Log to reflect a more accurate identifier, also wrapped it in a try-catch to catch any DB delete fails.

#### AlbumsAPI
* GetAll: added null check
* GetOne: added null check and updated the json results to include details on a fail. Also added a log to check how many users miss this endpoint (for better documentation?).
* DeleteOne: added null check, and a try-catch to try and delete an album, and to catch any DB delete fails, and updated the json results to return accurate errors to the user.

#### Program.cs
* added generic Serilog Logger.

## Reasoning
* Null checks were added to attempt to eliminate errors that would otherwise break the program, this allows the users to enjoy a more fluid experience and on the off chance there is an error, the application won't break.
* Additionally, along the same lines the error messages and returns were updated to show the user why something is failing and that it is failing in the first place. All silent fails should be eliminated, but there is room for improvement in the html to display the error messages.
* Lastly, try-catch's were implemented in most actions allowing for accurate errors to be collected and with a count of the errors so that devs can look back and see how many people ran into problems creating a new album, or how many people mistyped an API endpoint.